### PR TITLE
Implementación para la issue #17 - Soporte para nuevas estaciones con desbloqueo vía QR

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,9 @@ dependencies {
     testImplementation 'io.insert-koin:koin-test:3.5.0'
     testImplementation 'io.insert-koin:koin-test-junit4:3.5.0'
 
+    // QR code scanner
+    implementation("io.github.g00fy2.quickie:quickie-bundled:1.10.0")
+
     // Network
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,7 @@ android {
     }
     buildFeatures {
         compose true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion "1.5.4"
@@ -71,6 +72,10 @@ dependencies {
     // Dependency injection
     implementation 'io.insert-koin:koin-android:3.5.0'
     implementation 'io.insert-koin:koin-androidx-compose:3.5.0'
+    implementation 'androidx.camera:camera-core:1.4.2'
+    implementation 'androidx.camera:camera-lifecycle:1.4.2'
+    implementation 'androidx.camera:camera-view:1.4.2'
+    implementation 'com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1'
     testImplementation 'io.insert-koin:koin-test:3.5.0'
     testImplementation 'io.insert-koin:koin-test-junit4:3.5.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,10 +72,6 @@ dependencies {
     // Dependency injection
     implementation 'io.insert-koin:koin-android:3.5.0'
     implementation 'io.insert-koin:koin-androidx-compose:3.5.0'
-    implementation 'androidx.camera:camera-core:1.4.2'
-    implementation 'androidx.camera:camera-lifecycle:1.4.2'
-    implementation 'androidx.camera:camera-view:1.4.2'
-    implementation 'com.google.android.gms:play-services-mlkit-barcode-scanning:18.3.1'
     testImplementation 'io.insert-koin:koin-test:3.5.0'
     testImplementation 'io.insert-koin:koin-test-junit4:3.5.0'
 

--- a/app/src/main/kotlin/com/tcn/bicicas/data/Result.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/Result.kt
@@ -1,5 +1,6 @@
 package com.tcn.bicicas.data
 
+import android.util.Log
 import com.tcn.bicicas.data.model.HttpError
 import com.tcn.bicicas.data.model.NetworkError
 import com.tcn.bicicas.data.model.Token
@@ -21,8 +22,9 @@ suspend fun <T : Any> resultOf(call: suspend () -> Response<T>): Result<Pair<Res
     return try {
         val response = call()
         when {
-            !response.isSuccessful ->
-                Result.failure(HttpError(response.code(), response.raw().body?.toString()))
+            !response.isSuccessful -> {
+                Result.failure(HttpError(response.code(), response.errorBody()?.string()))
+            }
 
             response.body() != null -> Result.success(response to response.body()!!)
             else -> Result.failure(UnknownError())

--- a/app/src/main/kotlin/com/tcn/bicicas/data/Result.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/Result.kt
@@ -2,6 +2,7 @@ package com.tcn.bicicas.data
 
 import com.tcn.bicicas.data.model.HttpError
 import com.tcn.bicicas.data.model.NetworkError
+import com.tcn.bicicas.data.model.Token
 import kotlinx.coroutines.CancellationException
 import retrofit2.HttpException
 import retrofit2.Response
@@ -10,10 +11,9 @@ import java.io.IOException
 
 inline fun <T, R> Result<T>.andThen(transform: (T) -> Result<R>): Result<R> {
     return fold(
-        onSuccess = { value -> transform(value) },
+        onSuccess = { value -> transform(value) }, // Return Result<R> from the transform function
         onFailure = { exception -> Result.failure(exception) }
     )
-
 }
 
 

--- a/app/src/main/kotlin/com/tcn/bicicas/data/datasource/local/TokenAuthStore.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/datasource/local/TokenAuthStore.kt
@@ -1,0 +1,36 @@
+package com.tcn.bicicas.data.datasource.local
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.tcn.bicicas.data.model.Token
+import org.jasypt.util.text.BasicTextEncryptor
+
+
+class TokenAuthStore(
+    private val preferences: SharedPreferences,
+    password: CharArray
+) : LocalStore<Token> {
+
+    companion object {
+        private const val TOKEN_KEY = "tokenAuth.token"
+    }
+
+    private val encryptor = BasicTextEncryptor().apply { setPasswordCharArray(password) }
+
+    override fun get(): Token? = runCatching {
+        val token = preferences.getString(TOKEN_KEY, null)?.let(encryptor::decrypt)
+        Token( token ?: return null)
+    }.getOrNull()
+
+    override fun save(value: Token) =
+        preferences.edit {
+            putString(TOKEN_KEY, encryptor.encrypt(value.value))
+        }
+
+    override fun clear() =
+        preferences.edit {
+            remove(TOKEN_KEY)
+        }
+
+
+}

--- a/app/src/main/kotlin/com/tcn/bicicas/data/datasource/remote/SecretApi.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/datasource/remote/SecretApi.kt
@@ -1,5 +1,6 @@
 package com.tcn.bicicas.data.datasource.remote
 
+import com.tcn.bicicas.data.model.Loan
 import com.tcn.bicicas.data.model.Token
 import com.tcn.bicicas.data.model.TwoFactorAuth
 import retrofit2.Response
@@ -14,12 +15,15 @@ interface SecretApi {
     suspend fun authenticate(
         @Query("username") username: String,
         @Query("password") password: String,
-        @Query("client_id") clientId: String,
-        @Query("client_secret") clientSecret: String,
-        @Query("grant_type") grantType: String,
     ): Response<Token>
 
     @GET("dashboard")
-    suspend fun getTwoFactorAuth(@Header("Authorization") token: String): Response<TwoFactorAuth>
+    suspend fun getTwoFactorAuth(@Header("authorization") token: String): Response<TwoFactorAuth>
+
+    @POST("loans")
+    suspend fun remoteLoan(
+        @Header("authorization") token: String,
+        @Query("qrcode") qrcode: String,
+        @Query("is_electric") isElectric: Boolean) : Response<Loan>
 
 }

--- a/app/src/main/kotlin/com/tcn/bicicas/data/datasource/remote/serialization/ApiConverter.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/datasource/remote/serialization/ApiConverter.kt
@@ -1,5 +1,6 @@
 package com.tcn.bicicas.data.datasource.remote.serialization
 
+import com.tcn.bicicas.data.model.Loan
 import com.tcn.bicicas.data.model.Station
 import com.tcn.bicicas.data.model.Token
 import com.tcn.bicicas.data.model.TwoFactorAuth
@@ -19,6 +20,7 @@ class ApiConverter : Converter.Factory() {
             Token::class.java -> TokenConverter()
             TwoFactorAuth::class.java -> TwoFactorAuthConverter()
             Array<Station>::class.java -> StationConverter()
+            Loan::class.java -> LoanConverter()
             else -> null
         }
     }

--- a/app/src/main/kotlin/com/tcn/bicicas/data/datasource/remote/serialization/LoanConverter.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/datasource/remote/serialization/LoanConverter.kt
@@ -1,0 +1,13 @@
+package com.tcn.bicicas.data.datasource.remote.serialization
+
+import com.tcn.bicicas.data.model.Loan
+import okhttp3.ResponseBody
+import org.json.JSONObject
+import retrofit2.Converter
+
+class LoanConverter : Converter<ResponseBody, Loan> {
+    override fun convert(value: ResponseBody): Loan {
+        return JSONObject(value.string())
+            .run { Loan(getString("use_uuid")) }
+    }
+}

--- a/app/src/main/kotlin/com/tcn/bicicas/data/model/Loan.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/model/Loan.kt
@@ -1,0 +1,3 @@
+package com.tcn.bicicas.data.model
+
+data class Loan (val value: String)

--- a/app/src/main/kotlin/com/tcn/bicicas/data/model/Loan.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/model/Loan.kt
@@ -1,3 +1,5 @@
 package com.tcn.bicicas.data.model
 
-data class Loan (val value: String)
+data class Loan (
+    val use_uuid: String
+)

--- a/app/src/main/kotlin/com/tcn/bicicas/data/repository/LoanRepository.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/repository/LoanRepository.kt
@@ -13,25 +13,23 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import org.koin.androidx.compose.get
 
 class LoanRepository(
     private val secretApi: SecretApi,
     private val tokenAuthStore: LocalStore<Token>
 ) {
-
     private val _authenticatedState = MutableStateFlow(false)
     val authenticatedState: StateFlow<Boolean> = _authenticatedState.asStateFlow()
 
-    init {
-        tokenAuthStore.get()?.let { tokenAuth ->
-            CoroutineScope(Dispatchers.IO).launch {
-                checkToken(tokenAuth.value).onSuccess{
-                    onTokenObtained(tokenAuth)
-
-                }
-            }
+    init{
+        if (getToken() != null){
+            _authenticatedState.update { true }
+        } else {
+            _authenticatedState.update { false }
         }
     }
+
     suspend fun authenticate(username: String, password: String): Result<Token> {
         return doAuthRequest(username, password)
             .onSuccess { token -> onTokenObtained(token) }
@@ -61,9 +59,11 @@ class LoanRepository(
         return tokenAuthStore.get()
     }
 
-    private suspend fun checkToken(token: String): Result<TwoFactorAuth> {
-        return resultOf { secretApi.getTwoFactorAuth("Bearer $token") }
+    suspend fun checkToken() {
+        val token = getToken()?.value
+        val result = resultOf { secretApi.getTwoFactorAuth("Bearer $token") }
             .map { (_, twoFactorAuth) -> twoFactorAuth }
+        result.onSuccess { _authenticatedState.update { true } }
     }
 
     suspend fun loanBike(  qrcode: String): Result <Loan>{

--- a/app/src/main/kotlin/com/tcn/bicicas/data/repository/LoanRepository.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/repository/LoanRepository.kt
@@ -1,0 +1,68 @@
+package com.tcn.bicicas.data.repository
+
+import com.tcn.bicicas.data.datasource.local.LocalStore
+import com.tcn.bicicas.data.datasource.remote.SecretApi
+import com.tcn.bicicas.data.model.Token
+import com.tcn.bicicas.data.model.TwoFactorAuth
+import com.tcn.bicicas.data.resultOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class LoanRepository(
+    private val secretApi: SecretApi,
+    private val tokenAuthStore: LocalStore<Token>
+) {
+
+    private val _authenticatedState = MutableStateFlow(false)
+    val authenticatedState: StateFlow<Boolean> = _authenticatedState.asStateFlow()
+
+    init {
+        tokenAuthStore.get()?.let { tokenAuth ->
+            CoroutineScope(Dispatchers.IO).launch {
+                checkToken(tokenAuth.value).onSuccess{
+                    onTokenObtained(tokenAuth)
+
+                }
+            }
+        }
+    }
+    suspend fun authenticate(username: String, password: String): Result<Token> {
+        return doAuthRequest(username, password)
+            .onSuccess { token -> onTokenObtained(token) }
+    }
+
+    fun logout() {
+        tokenAuthStore.clear()
+        _authenticatedState.update { false }
+    }
+
+    private suspend fun doAuthRequest(username: String, password: String): Result<Token> {
+        return resultOf {
+            secretApi.authenticate(
+                username = username,
+                password = password,
+            )
+        }.map { (_, token) -> token }
+    }
+
+    @Synchronized
+    private fun onTokenObtained(token: Token) {
+        tokenAuthStore.save(token)
+        _authenticatedState.update { true }
+    }
+
+    fun getToken(): Token? {
+        return tokenAuthStore.get()
+    }
+
+    private suspend fun checkToken(token: String): Result<TwoFactorAuth> {
+        return resultOf { secretApi.getTwoFactorAuth("Bearer $token") }
+            .map { (_, twoFactorAuth) -> twoFactorAuth }
+    }
+
+}

--- a/app/src/main/kotlin/com/tcn/bicicas/data/repository/LoanRepository.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/repository/LoanRepository.kt
@@ -2,6 +2,7 @@ package com.tcn.bicicas.data.repository
 
 import com.tcn.bicicas.data.datasource.local.LocalStore
 import com.tcn.bicicas.data.datasource.remote.SecretApi
+import com.tcn.bicicas.data.model.Loan
 import com.tcn.bicicas.data.model.Token
 import com.tcn.bicicas.data.model.TwoFactorAuth
 import com.tcn.bicicas.data.resultOf
@@ -65,4 +66,11 @@ class LoanRepository(
             .map { (_, twoFactorAuth) -> twoFactorAuth }
     }
 
+    suspend fun loanBike(  qrcode: String): Result <Loan>{
+        val token = tokenAuthStore.get()?.value
+        return token?.let {
+            resultOf { secretApi.remoteLoan("Bearer $it", qrcode, false) }
+                .map { (_, twoFactorAuth) -> twoFactorAuth }
+        } ?: Result.failure(IllegalStateException("Token is null"))
+    }
 }

--- a/app/src/main/kotlin/com/tcn/bicicas/data/repository/PinRepository.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/data/repository/PinRepository.kt
@@ -1,9 +1,7 @@
 package com.tcn.bicicas.data.repository
 
-import com.tcn.bicicas.data.andThen
 import com.tcn.bicicas.data.datasource.local.LocalStore
 import com.tcn.bicicas.data.datasource.remote.SecretApi
-import com.tcn.bicicas.data.model.Token
 import com.tcn.bicicas.data.model.TwoFactorAuth
 import com.tcn.bicicas.data.resultOf
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,8 +14,6 @@ import pingenerator.api.PinGeneratorFactory
 class PinRepository(
     private val secretApi: SecretApi,
     private val twoFactorStore: LocalStore<TwoFactorAuth>,
-    private val clientId: String,
-    private val clientSecret: String,
 ) {
 
     private var user: String? = null
@@ -31,10 +27,8 @@ class PinRepository(
         }
     }
 
-    suspend fun authenticate(username: String, password: String): Result<TwoFactorAuth> {
-        return doAuthRequest(username, password)
-            .andThen { token -> getTwoFactorAuth(token.value) }
-            .onSuccess { twoFactorAuth -> onTwoFactorAuthObtained(twoFactorAuth) }
+    suspend fun authenticateTwoFactor(token: String): Result<TwoFactorAuth> {
+            return getTwoFactorAuth(token).onSuccess { twoFactorAuth -> onTwoFactorAuthObtained(twoFactorAuth) }
     }
 
     fun getPin(time: Long): String? = pinGenerator?.generatePin(time)
@@ -47,17 +41,6 @@ class PinRepository(
 
     fun getUserNumber(): String? = user
 
-    private suspend fun doAuthRequest(username: String, password: String): Result<Token> {
-        return resultOf {
-            secretApi.authenticate(
-                username = username,
-                password = password,
-                clientId = clientId,
-                clientSecret = clientSecret,
-                grantType = "password",
-            )
-        }.map { (_, token) -> token }
-    }
 
     @Synchronized
     private fun onTwoFactorAuthObtained(twoFactorAuth: TwoFactorAuth) {

--- a/app/src/main/kotlin/com/tcn/bicicas/di/LoanModule.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/di/LoanModule.kt
@@ -1,0 +1,23 @@
+package com.tcn.bicicas.di
+
+import com.tcn.bicicas.BuildConfig
+import com.tcn.bicicas.data.datasource.local.TokenAuthStore
+import com.tcn.bicicas.data.repository.LoanRepository
+import com.tcn.bicicas.ui.loan.LoanViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+import retrofit2.Retrofit
+import retrofit2.create
+
+fun loanModule(baseUrl: String = BuildConfig.OAUTH_ENDPOINT) = module {
+    single {
+        LoanRepository(
+            secretApi = get<Retrofit.Builder>().baseUrl(baseUrl).build()
+                .create(),
+            tokenAuthStore = TokenAuthStore(get(), BuildConfig.ENCRYPT_PASSWORD.toCharArray())
+        )
+    }
+
+    viewModel { LoanViewModel(get()) }
+
+}

--- a/app/src/main/kotlin/com/tcn/bicicas/di/MainModules.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/di/MainModules.kt
@@ -7,5 +7,6 @@ val mainModules = listOf(
     preferencesModule,
     settingsModule,
     pinModule(),
+    loanModule(),
     stationModule()
 )

--- a/app/src/main/kotlin/com/tcn/bicicas/di/NetworkModule.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/di/NetworkModule.kt
@@ -11,6 +11,8 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.dsl.module
 import retrofit2.Retrofit
+import java.sql.Time
+import java.util.concurrent.TimeUnit
 
 val networkModule = module {
     single { provideRetrofitBuilder(getOrNull()) }
@@ -19,6 +21,10 @@ val networkModule = module {
 private fun provideRetrofitBuilder(context: Context?) = Retrofit.Builder()
     .client(
         OkHttpClient.Builder()
+            .callTimeout(120, TimeUnit.SECONDS)
+            .connectTimeout(20 , TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30,TimeUnit.SECONDS)
             .cache(context?.cacheDir?.let { file -> Cache(file, 1024 * 1024) })
             .addInterceptor(HttpLoggingInterceptor().apply {
                 level = when {

--- a/app/src/main/kotlin/com/tcn/bicicas/di/PinModule.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/di/PinModule.kt
@@ -1,6 +1,7 @@
 package com.tcn.bicicas.di
 
 import com.tcn.bicicas.BuildConfig
+import com.tcn.bicicas.data.datasource.local.TokenAuthStore
 import com.tcn.bicicas.data.datasource.local.TwoFactorAuthStore
 import com.tcn.bicicas.data.repository.PinRepository
 import com.tcn.bicicas.ui.pin.PinViewModel
@@ -15,11 +16,9 @@ fun pinModule(baseUrl: String = BuildConfig.OAUTH_ENDPOINT) = module {
             secretApi = get<Retrofit.Builder>().baseUrl(baseUrl).build()
                 .create(),
             twoFactorStore = TwoFactorAuthStore(get(), BuildConfig.ENCRYPT_PASSWORD.toCharArray()),
-            clientId = BuildConfig.OAUTH_CLIENT_ID,
-            clientSecret = BuildConfig.OAUTH_CLIENT_SECRET,
         )
     }
 
-    viewModel { PinViewModel(get(), get()) }
+    viewModel { PinViewModel(get(),get(), get()) }
 
 }

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/components/login/LoginContract.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/components/login/LoginContract.kt
@@ -1,0 +1,8 @@
+package com.tcn.bicicas.ui.components.login
+
+import androidx.compose.runtime.Immutable
+
+
+enum class LoginError {
+        WrongUserPass, Network, Unknown
+    }

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/components/login/LoginDialog.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/components/login/LoginDialog.kt
@@ -1,4 +1,4 @@
-package com.tcn.bicicas.ui.pin
+package com.tcn.bicicas.ui.components.login
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -43,11 +43,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import com.tcn.bicicas.R
+import com.tcn.bicicas.ui.pin.PinState
 
 
 @Composable
 fun LoginDialog(
-    loginError: PinState.LoginError?,
+    loginError: LoginError?,
     isLoading: Boolean,
     onDismissRequest: () -> Unit,
     onLogin: (String, String) -> Unit
@@ -67,7 +68,7 @@ fun LoginDialog(
 
 @Composable
 private fun LoginContent(
-    loginError: PinState.LoginError?,
+    loginError: LoginError?,
     isLoading: Boolean,
     onLoginClicked: (String, String) -> Unit
 ) {
@@ -97,9 +98,9 @@ private fun LoginContent(
 
         Text(
             text = when (loginError) {
-                PinState.LoginError.WrongUserPass -> stringResource(R.string.pin_login_error_wrong_user_pass)
-                PinState.LoginError.Network -> stringResource(R.string.pin_login_error_network)
-                PinState.LoginError.Unknown -> stringResource(R.string.pin_login_error_unknown)
+                LoginError.WrongUserPass -> stringResource(R.string.pin_login_error_wrong_user_pass)
+                LoginError.Network -> stringResource(R.string.pin_login_error_network)
+                LoginError.Unknown -> stringResource(R.string.pin_login_error_unknown)
                 null -> ""
             },
             textAlign = TextAlign.Center

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanContract.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanContract.kt
@@ -10,4 +10,12 @@ data class LoanState(
     val loading: Boolean = false,
     val loggedIn: Boolean = false,
     val loginError: LoginError? = null,
-)
+
+    val loanSuccess: Boolean = false,
+    val loanLoading: Boolean = false,
+    val loanError: LoanError? = null,
+
+) {enum class LoanError {
+    Unauthenticated, NoBicycle, NoQRCode, Network, Unknown
+}
+}

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanContract.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanContract.kt
@@ -1,16 +1,12 @@
-package com.tcn.bicicas.ui.pin
+package com.tcn.bicicas.ui.loan
+
 
 import androidx.compose.runtime.Immutable
 import com.tcn.bicicas.ui.components.login.LoginError
 
 
 @Immutable
-data class PinState(
-    val timeText: String? = null,
-    val progress: Float = 0f,
-    val pin: String? = null,
-    val nextPin: String? = null,
-    val userNumber: String? = null,
+data class LoanState(
     val loading: Boolean = false,
     val loggedIn: Boolean = false,
     val loginError: LoginError? = null,

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
@@ -5,12 +5,14 @@ import com.tcn.bicicas.ui.components.login.LoginDialog
 import com.tcn.bicicas.ui.pin.PinState
 
 import android.content.res.Configuration
+import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,15 +24,19 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Undo
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -46,6 +52,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -53,6 +60,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.tcn.bicicas.R
 import com.tcn.bicicas.ui.components.ScrollableAlertDialog
 import io.github.g00fy2.quickie.QRResult
@@ -66,7 +75,7 @@ import org.koin.androidx.compose.getViewModel
 fun LoanScreen(padding: PaddingValues) {
     val viewModel: LoanViewModel = getViewModel()
     val state by viewModel.loanState.collectAsState()
-    LoanScreen(state, padding, viewModel::logout, viewModel::login)
+    LoanScreen(state, padding, viewModel::logout, viewModel::login, viewModel::loanBike, viewModel::onLoanMsgShown)
 }
 
 @Composable
@@ -74,10 +83,12 @@ fun LoanScreen(
     state: LoanState,
     padding: PaddingValues,
     onLogout: () -> Unit,
-    onLogin: (String, String) -> Unit
+    onLogin: (String, String) -> Unit,
+    loanBike: (String) -> Unit,
+    onLoanMsgShown: () -> Unit
 ) {
     if (state.loggedIn) {
-        LoanContent(state, padding, onLogout)
+        LoanContent(state, padding, onLogout, loanBike, onLoanMsgShown)
     } else {
         LoanWelcomeContent(state, padding, onLogin)
     }
@@ -168,7 +179,7 @@ private fun LoanWelcomeContent(
 
 
 @Composable
-private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -> Unit) {
+private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -> Unit, loanBike: (String) -> Unit,  onLoanMsgShown: () -> Unit) {
     var displayLogoutDialog by rememberSaveable { mutableStateOf(false) }
     val onLogoutClicked = { displayLogoutDialog = true }
     Surface(
@@ -178,10 +189,43 @@ private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -
     ) {
 
         if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) {
-            PortraitLoanContent(state, onLogoutClicked)
+            PortraitLoanContent(state, onLogoutClicked, loanBike)
         } else {
             LandscapeLoanContent(state, onLogoutClicked)
         }
+    }
+
+
+    LoadingDialog(state.loanLoading)
+
+    // show loanSuccess
+    if (state.loanSuccess){
+        AlertDialog(
+            onDismissRequest = {         onLoanMsgShown() },
+            title = { Text("Éxito") },
+            text = { Text("Prestamo realizado correctamente") },
+            confirmButton = { TextButton(onClick = onLoanMsgShown) { Text(stringResource(R.string.popup_accept)) } },
+        )
+    }
+
+    // show loanError
+    if (state.loanError != null){
+        val errMsg = when(state.loanError){
+            LoanState.LoanError.Unauthenticated -> "Se ha cerrado la sesión"
+            LoanState.LoanError.NoBicycle -> "No hay bicicleta en este anclaje"
+            LoanState.LoanError.NoQRCode -> "El código QR no existe"
+            LoanState.LoanError.Network -> "Problema de red"
+            LoanState.LoanError.Unknown -> "Error desconocido"
+        }
+
+        AlertDialog(
+            onDismissRequest = {         onLoanMsgShown() },
+            title = { Text("Error en el prestamo") },
+            text = { Text(errMsg) },
+            confirmButton = { TextButton(onClick = onLoanMsgShown) { Text(stringResource(R.string.popup_accept)) } },
+        )
+
+
     }
 
     if (displayLogoutDialog) {
@@ -200,15 +244,22 @@ private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -
         )
     }
 
+
+
 }
 
 @Composable
-private fun PortraitLoanContent(state: LoanState, onLogoutButtonClicked: () -> Unit) {
+private fun PortraitLoanContent(
+    state: LoanState,
+    onLogoutButtonClicked: () -> Unit,
+    loanBike:(String) -> Unit
+) {
+    val inputText = remember { mutableStateOf("") }
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-
         // Logout
         TextButton(
             onClick = onLogoutButtonClicked,
@@ -218,45 +269,79 @@ private fun PortraitLoanContent(state: LoanState, onLogoutButtonClicked: () -> U
         ) {
             Text(stringResource(R.string.pin_logout))
         }
-        val ctx = LocalContext.current
-        val scanQrCodeLauncher = rememberLauncherForActivityResult(ScanCustomCode()) { result ->
-            val text = when (result) {
-                is QRResult.QRSuccess -> {
-                    result.content.rawValue
-                    // decoding with default UTF-8 charset when rawValue is null will not result in meaningful output, demo purpose
-                        ?: result.content.rawBytes?.let { String(it) }.orEmpty()
-                }
-                QRResult.QRUserCanceled -> "User canceled"
-                QRResult.QRMissingPermission -> "Missing permission"
-                is QRResult.QRError -> "${result.exception.javaClass.simpleName}: ${result.exception.localizedMessage}"
-            }
-            // handle QRResult
-            Toast.makeText(ctx, text, Toast.LENGTH_LONG).show()
-        }
+
+        Spacer(Modifier.weight(0.1f))
+
+
+        // Manual number entering
+        OutlinedTextField(
+            value = inputText.value,
+            onValueChange = { newText ->
+                val filteredText = newText.uppercase().filter { it.isLetterOrDigit() }.take(3)
+                inputText.value = filteredText },
+            label = { Text("Código QR") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        )
 
         Button(
             onClick = {
-                scanQrCodeLauncher.launch( ScannerConfig.build {
-                    setBarcodeFormats(listOf(BarcodeFormat.FORMAT_QR_CODE)) // set interested barcode formats
-                    setOverlayStringRes(R.string.app_name) // string resource used for the scanner overlay
-                    //setOverlayDrawableRes(R.drawable.ic_scan_barcode) // drawable resource used for the scanner overlay
-                    setHapticSuccessFeedback(false) // enable (default) or disable haptic feedback when a barcode was detected
-                    setShowTorchToggle(true) // show or hide (default) torch/flashlight toggle button
-                    setShowCloseButton(true) // show or hide (default) close button
-                    setHorizontalFrameRatio(1f) // set the horizontal overlay ratio (default is 1 / square frame)
-                    setUseFrontCamera(false) // use the front camera
-                    setKeepScreenOn(true) // keep the device's screen turned on
+                loanBike(inputText.value)
+            },
+            modifier = Modifier
+                .padding(16.dp)
+                .align(Alignment.CenterHorizontally)
+        ) {
+            Text("Desbloquear ")
+        }
+
+        // QR code scan
+        val scanQrCodeLauncher = rememberLauncherForActivityResult(ScanCustomCode()) { result ->
+            when (result) {
+                is QRResult.QRSuccess -> {
+                    result.content.rawValue?.let{loanBike(it)}
+
+                }
+                QRResult.QRUserCanceled -> {
+                    Log.e("QR", "UserCanceled")
+                }
+                QRResult.QRMissingPermission -> {
+                    Log.e("QR", "MissingPermission")
+                }
+                is QRResult.QRError -> {
+                    Log.e("QR","${result.exception.javaClass.simpleName}: ${result.exception.localizedMessage}")
+                }
+            }
+        }
+
+        Spacer(Modifier.weight(0.8f))
+
+        Button(
+            onClick = {
+                scanQrCodeLauncher.launch(ScannerConfig.build {
+                    setBarcodeFormats(listOf(BarcodeFormat.FORMAT_QR_CODE))
+                    setOverlayStringRes(R.string.qr_scan_string)
+                    setHapticSuccessFeedback(false)
+                    setShowTorchToggle(true)
+                    setShowCloseButton(true)
+                    setHorizontalFrameRatio(1f)
+                    setUseFrontCamera(false)
+                    setKeepScreenOn(true)
                 })
             },
             modifier = Modifier.padding(16.dp)
+                .height(120.dp)  // Make the button taller
+                .fillMaxWidth()
         ) {
-            Text(text = "Escanear código QR")
+            Text(text = stringResource(R.string.escanear_c_digo_qr),
+                fontSize = 24.sp)
         }
+        Spacer(Modifier.weight(0.2f))
 
-        Spacer(Modifier.weight(1f))
-        Spacer(Modifier.height(24.dp))
     }
 }
+
 
 @Composable
 private fun LandscapeLoanContent(state: LoanState, onLogoutButtonClicked: () -> Unit) {
@@ -271,21 +356,37 @@ private fun LandscapeLoanContent(state: LoanState, onLogoutButtonClicked: () -> 
         ) {
             Text(stringResource(R.string.pin_logout))
         }
-
-
     }
 }
 
+
 @Composable
-private fun UserText(userNumber: String?, modifier: Modifier = Modifier) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier) {
-        Text(
-            text = stringResource(R.string.pin_label_user),
-            style = MaterialTheme.typography.titleMedium
-        )
-        Text(
-            text = userNumber ?: "",
-            style = MaterialTheme.typography.displayLarge.copy(fontSize = 48.sp)
-        )
+fun LoadingDialog(isShowingDialog: Boolean) {
+    if (isShowingDialog) {
+        Dialog(
+            onDismissRequest = { },
+            DialogProperties(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(160.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.background,
+                        shape = RoundedCornerShape(16.dp)
+                    )
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .size(100.dp)
+                        .align(Alignment.Center)
+                        ,
+                    color = MaterialTheme.colorScheme.primary,
+                    strokeWidth = 10.dp
+                )
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
@@ -1,17 +1,11 @@
 package com.tcn.bicicas.ui.loan
 
-import android.content.Intent
+
 import com.tcn.bicicas.ui.components.login.LoginDialog
-import com.tcn.bicicas.ui.pin.PinState
 
 import android.content.res.Configuration
 import android.util.Log
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,21 +13,18 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Undo
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -41,7 +32,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,13 +40,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -66,7 +51,6 @@ import com.tcn.bicicas.R
 import com.tcn.bicicas.ui.components.ScrollableAlertDialog
 import io.github.g00fy2.quickie.QRResult
 import io.github.g00fy2.quickie.ScanCustomCode
-import io.github.g00fy2.quickie.ScanQRCode
 import io.github.g00fy2.quickie.config.BarcodeFormat
 import io.github.g00fy2.quickie.config.ScannerConfig
 import org.koin.androidx.compose.getViewModel
@@ -114,7 +98,7 @@ private fun LoanWelcomeContent(
         ) {
             Spacer(modifier = Modifier.weight(0.5f))
             Text(
-                text = stringResource(R.string.desbloqueo_mediante_codigo_qr),
+                text = stringResource(R.string.loans_qr_code_unlocking_msg),
                 style = MaterialTheme.typography.headlineMedium,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.sizeIn(maxWidth = 600.dp),
@@ -191,7 +175,7 @@ private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -
         if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) {
             PortraitLoanContent(state, onLogoutClicked, loanBike)
         } else {
-            LandscapeLoanContent(state, onLogoutClicked)
+            LandscapeLoanContent(state, onLogoutClicked, loanBike)
         }
     }
 
@@ -202,8 +186,8 @@ private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -
     if (state.loanSuccess){
         AlertDialog(
             onDismissRequest = {         onLoanMsgShown() },
-            title = { Text("Éxito") },
-            text = { Text("Prestamo realizado correctamente") },
+            title = { Text(stringResource(R.string.popup_success)) },
+            text = { Text(stringResource(R.string.loans_success)) },
             confirmButton = { TextButton(onClick = onLoanMsgShown) { Text(stringResource(R.string.popup_accept)) } },
         )
     }
@@ -211,16 +195,16 @@ private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -
     // show loanError
     if (state.loanError != null){
         val errMsg = when(state.loanError){
-            LoanState.LoanError.Unauthenticated -> "Se ha cerrado la sesión"
-            LoanState.LoanError.NoBicycle -> "No hay bicicleta en este anclaje"
-            LoanState.LoanError.NoQRCode -> "El código QR no existe"
-            LoanState.LoanError.Network -> "Problema de red"
-            LoanState.LoanError.Unknown -> "Error desconocido"
+            LoanState.LoanError.Unauthenticated -> stringResource(R.string.loans_error_unauthenticated)
+            LoanState.LoanError.NoBicycle -> stringResource(R.string.loans_error_no_bicycle)
+            LoanState.LoanError.NoQRCode -> stringResource(R.string.loans_error_no_qr)
+            LoanState.LoanError.Network -> stringResource(R.string.loans_error_network)
+            LoanState.LoanError.Unknown -> stringResource(R.string.loans_error_unknown)
         }
 
         AlertDialog(
             onDismissRequest = {         onLoanMsgShown() },
-            title = { Text("Error en el prestamo") },
+            title = { Text(stringResource(R.string.popup_error_title)) },
             text = { Text(errMsg) },
             confirmButton = { TextButton(onClick = onLoanMsgShown) { Text(stringResource(R.string.popup_accept)) } },
         )
@@ -231,7 +215,7 @@ private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -
     if (displayLogoutDialog) {
         AlertDialog(
             onDismissRequest = { displayLogoutDialog = false },
-            title = { Text(stringResource(R.string.pin_logout)) },
+            title = { Text(stringResource(R.string.logout)) },
             text = { Text(stringResource(R.string.pin_logout_popup_text)) },
             confirmButton = { TextButton(onClick = onLogout) { Text(stringResource(R.string.popup_accept)) } },
             dismissButton = {
@@ -267,7 +251,7 @@ private fun PortraitLoanContent(
                 .align(Alignment.End)
                 .padding(vertical = 12.dp, horizontal = 4.dp)
         ) {
-            Text(stringResource(R.string.pin_logout))
+            Text(stringResource(R.string.logout))
         }
 
         Spacer(Modifier.weight(0.1f))
@@ -279,7 +263,7 @@ private fun PortraitLoanContent(
             onValueChange = { newText ->
                 val filteredText = newText.uppercase().filter { it.isLetterOrDigit() }.take(3)
                 inputText.value = filteredText },
-            label = { Text("Código QR") },
+            label = { Text(stringResource(R.string.loans_qr_code_text_input)) },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
@@ -293,7 +277,7 @@ private fun PortraitLoanContent(
                 .padding(16.dp)
                 .align(Alignment.CenterHorizontally)
         ) {
-            Text("Desbloquear ")
+            Text(stringResource(R.string.loans_unlock_btn))
         }
 
         // QR code scan
@@ -321,7 +305,7 @@ private fun PortraitLoanContent(
             onClick = {
                 scanQrCodeLauncher.launch(ScannerConfig.build {
                     setBarcodeFormats(listOf(BarcodeFormat.FORMAT_QR_CODE))
-                    setOverlayStringRes(R.string.qr_scan_string)
+                    setOverlayStringRes(R.string.loans_qr_scan_string)
                     setHapticSuccessFeedback(false)
                     setShowTorchToggle(true)
                     setShowCloseButton(true)
@@ -330,11 +314,12 @@ private fun PortraitLoanContent(
                     setKeepScreenOn(true)
                 })
             },
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier
+                .padding(16.dp)
                 .height(120.dp)  // Make the button taller
                 .fillMaxWidth()
         ) {
-            Text(text = stringResource(R.string.escanear_c_digo_qr),
+            Text(text = stringResource(R.string.loans_qr_scan_string),
                 fontSize = 24.sp)
         }
         Spacer(Modifier.weight(0.2f))
@@ -344,17 +329,98 @@ private fun PortraitLoanContent(
 
 
 @Composable
-private fun LandscapeLoanContent(state: LoanState, onLogoutButtonClicked: () -> Unit) {
-    Box(modifier = Modifier.fillMaxSize()) {
+private fun LandscapeLoanContent(
+    state: LoanState,
+    onLogoutButtonClicked: () -> Unit,
+    loanBike: (String) -> Unit
+) {
+    val inputText = remember { mutableStateOf("") }
 
-        // Logout button
-        TextButton(
-            onClick = onLogoutButtonClicked,
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        // Left Panel: Manual Input and Logout
+        Column(
             modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(vertical = 4.dp, horizontal = 12.dp)
+                .weight(1f)
+                .fillMaxHeight(),
+            verticalArrangement = Arrangement.SpaceBetween
         ) {
-            Text(stringResource(R.string.pin_logout))
+            // Logout Button
+            TextButton(
+                onClick = onLogoutButtonClicked,
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(vertical = 12.dp)
+            ) {
+                Text(stringResource(R.string.logout))
+            }
+
+            // Manual Text Input
+            OutlinedTextField(
+                value = inputText.value,
+                onValueChange = { newText ->
+                    val filteredText = newText.uppercase().filter { it.isLetterOrDigit() }.take(3)
+                    inputText.value = filteredText
+                },
+                label = { Text(stringResource(R.string.loans_qr_code_text_input)) },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            // Unlock Button
+            Button(
+                onClick = {
+                    loanBike(inputText.value)
+                },
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 8.dp)
+            ) {
+                Text(stringResource(R.string.loans_unlock_btn))
+            }
+        }
+
+        Spacer(modifier = Modifier.width(24.dp))
+
+        // Right Panel: QR Code Scanner
+        val scanQrCodeLauncher = rememberLauncherForActivityResult(ScanCustomCode()) { result ->
+            when (result) {
+                is QRResult.QRSuccess -> {
+                    result.content.rawValue?.let { loanBike(it) }
+                }
+                QRResult.QRUserCanceled -> Log.e("QR", "UserCanceled")
+                QRResult.QRMissingPermission -> Log.e("QR", "MissingPermission")
+                is QRResult.QRError -> Log.e("QR", "${result.exception.javaClass.simpleName}: ${result.exception.localizedMessage}")
+            }
+        }
+
+        Button(
+            onClick = {
+                scanQrCodeLauncher.launch(ScannerConfig.build {
+                    setBarcodeFormats(listOf(BarcodeFormat.FORMAT_QR_CODE))
+                    setOverlayStringRes(R.string.loans_qr_scan_string)
+                    setHapticSuccessFeedback(false)
+                    setShowTorchToggle(true)
+                    setShowCloseButton(true)
+                    setHorizontalFrameRatio(1f)
+                    setUseFrontCamera(false)
+                    setKeepScreenOn(true)
+                })
+            },
+            modifier = Modifier
+                .weight(1f)
+                .height(160.dp)
+                .fillMaxHeight()
+        ) {
+            Text(
+                text = stringResource(R.string.loans_qr_scan_string),
+                fontSize = 24.sp,
+                modifier = Modifier.padding(8.dp)
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
@@ -78,6 +78,36 @@ fun LoanScreen(
     } else {
         LoanWelcomeContent(state, padding, onLogin)
     }
+
+    // show loanSuccess
+    if (state.loanSuccess){
+        AlertDialog(
+            onDismissRequest = {         onLoanMsgShown() },
+            title = { Text(stringResource(R.string.popup_success)) },
+            text = { Text(stringResource(R.string.loans_success)) },
+            confirmButton = { TextButton(onClick = onLoanMsgShown) { Text(stringResource(R.string.popup_accept)) } },
+        )
+    }
+
+    // we can have errors even if we are not logged in
+    if (state.loanError != null){
+        val errMsg = when(state.loanError){
+            LoanState.LoanError.Unauthenticated -> stringResource(R.string.loans_error_unauthenticated)
+            LoanState.LoanError.NoBicycle -> stringResource(R.string.loans_error_no_bicycle)
+            LoanState.LoanError.NoQRCode -> stringResource(R.string.loans_error_no_qr)
+            LoanState.LoanError.Network -> stringResource(R.string.loans_error_network)
+            LoanState.LoanError.Unknown -> stringResource(R.string.loans_error_unknown)
+        }
+
+        AlertDialog(
+            onDismissRequest = {         onLoanMsgShown() },
+            title = { Text(stringResource(R.string.popup_error_title)) },
+            text = { Text(errMsg) },
+            confirmButton = { TextButton(onClick = onLoanMsgShown) { Text(stringResource(R.string.popup_accept)) } },
+        )
+
+
+    }
 }
 
 @Composable
@@ -184,35 +214,6 @@ private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -
 
     LoadingDialog(state.loanLoading)
 
-    // show loanSuccess
-    if (state.loanSuccess){
-        AlertDialog(
-            onDismissRequest = {         onLoanMsgShown() },
-            title = { Text(stringResource(R.string.popup_success)) },
-            text = { Text(stringResource(R.string.loans_success)) },
-            confirmButton = { TextButton(onClick = onLoanMsgShown) { Text(stringResource(R.string.popup_accept)) } },
-        )
-    }
-
-    // show loanError
-    if (state.loanError != null){
-        val errMsg = when(state.loanError){
-            LoanState.LoanError.Unauthenticated -> stringResource(R.string.loans_error_unauthenticated)
-            LoanState.LoanError.NoBicycle -> stringResource(R.string.loans_error_no_bicycle)
-            LoanState.LoanError.NoQRCode -> stringResource(R.string.loans_error_no_qr)
-            LoanState.LoanError.Network -> stringResource(R.string.loans_error_network)
-            LoanState.LoanError.Unknown -> stringResource(R.string.loans_error_unknown)
-        }
-
-        AlertDialog(
-            onDismissRequest = {         onLoanMsgShown() },
-            title = { Text(stringResource(R.string.popup_error_title)) },
-            text = { Text(errMsg) },
-            confirmButton = { TextButton(onClick = onLoanMsgShown) { Text(stringResource(R.string.popup_accept)) } },
-        )
-
-
-    }
 
     if (displayLogoutDialog) {
         AlertDialog(

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
@@ -261,7 +261,7 @@ private fun PortraitLoanContent(
         OutlinedTextField(
             value = inputText.value,
             onValueChange = { newText ->
-                val filteredText = newText.uppercase().filter { it.isLetterOrDigit() }.take(3)
+                val filteredText = newText.uppercase().filter { it in '0'..'9' || it in 'A'..'F' }.take(3)
                 inputText.value = filteredText },
             label = { Text(stringResource(R.string.loans_qr_code_text_input)) },
             modifier = Modifier
@@ -273,6 +273,7 @@ private fun PortraitLoanContent(
             onClick = {
                 loanBike(inputText.value)
             },
+            enabled = inputText.value.length == 3,
             modifier = Modifier
                 .padding(16.dp)
                 .align(Alignment.CenterHorizontally)
@@ -364,7 +365,7 @@ private fun LandscapeLoanContent(
             OutlinedTextField(
                 value = inputText.value,
                 onValueChange = { newText ->
-                    val filteredText = newText.uppercase().filter { it.isLetterOrDigit() }.take(3)
+                    val filteredText = newText.uppercase().filter { it in '0'..'9' || it in 'A'..'F' }.take(3)
                     inputText.value = filteredText
                 },
                 label = { Text(stringResource(R.string.loans_qr_code_text_input)) },
@@ -376,6 +377,7 @@ private fun LandscapeLoanContent(
                 onClick = {
                     loanBike(inputText.value)
                 },
+                enabled = inputText.value.length == 3,
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .padding(top = 8.dp)

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
@@ -1,20 +1,19 @@
-package com.tcn.bicicas.ui.pin
+package com.tcn.bicicas.ui.loan
+
+import com.tcn.bicicas.ui.components.login.LoginDialog
+import com.tcn.bicicas.ui.pin.PinState
 
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.Crossfade
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,7 +21,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Undo
 import androidx.compose.material3.AlertDialog
@@ -51,36 +49,33 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tcn.bicicas.R
-import com.tcn.bicicas.ui.components.AutoSizeText
-import com.tcn.bicicas.ui.components.CountDownIndicator
 import com.tcn.bicicas.ui.components.ScrollableAlertDialog
-import com.tcn.bicicas.ui.components.login.LoginDialog
 import org.koin.androidx.compose.getViewModel
 
 @Composable
-fun PinScreen(padding: PaddingValues) {
-    val viewModel: PinViewModel = getViewModel()
-    val state by viewModel.pinState.collectAsState()
-    PinScreen(state, padding, viewModel::logout, viewModel::login)
+fun LoanScreen(padding: PaddingValues) {
+    val viewModel: LoanViewModel = getViewModel()
+    val state by viewModel.loanState.collectAsState()
+    LoanScreen(state, padding, viewModel::logout, viewModel::login)
 }
 
 @Composable
-fun PinScreen(
-    state: PinState,
+fun LoanScreen(
+    state: LoanState,
     padding: PaddingValues,
     onLogout: () -> Unit,
     onLogin: (String, String) -> Unit
 ) {
     if (state.loggedIn) {
-        PinContent(state, padding, onLogout)
+        LoanContent(state, padding, onLogout)
     } else {
-        PinWelcomeContent(state, padding, onLogin)
+        LoanWelcomeContent(state, padding, onLogin)
     }
 }
 
 @Composable
-private fun PinWelcomeContent(
-    state: PinState,
+private fun LoanWelcomeContent(
+    state: LoanState,
     padding: PaddingValues,
     onLogin: (String, String) -> Unit
 ) {
@@ -98,7 +93,7 @@ private fun PinWelcomeContent(
         ) {
             Spacer(modifier = Modifier.weight(0.5f))
             Text(
-                text = stringResource(R.string.pin_welcome_title),
+                text = stringResource(R.string.desbloqueo_mediante_codigo_qr),
                 style = MaterialTheme.typography.headlineMedium,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.sizeIn(maxWidth = 600.dp),
@@ -163,7 +158,7 @@ private fun PinWelcomeContent(
 
 
 @Composable
-private fun PinContent(state: PinState, padding: PaddingValues, onLogout: () -> Unit) {
+private fun LoanContent(state: LoanState, padding: PaddingValues, onLogout: () -> Unit) {
     var displayLogoutDialog by rememberSaveable { mutableStateOf(false) }
     val onLogoutClicked = { displayLogoutDialog = true }
     Surface(
@@ -173,9 +168,9 @@ private fun PinContent(state: PinState, padding: PaddingValues, onLogout: () -> 
     ) {
 
         if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT) {
-            PortraitPinContent(state, onLogoutClicked)
+            PortraitLoanContent(state, onLogoutClicked)
         } else {
-            LandscapePinContent(state, onLogoutClicked)
+            LandscapeLoanContent(state, onLogoutClicked)
         }
     }
 
@@ -198,11 +193,12 @@ private fun PinContent(state: PinState, padding: PaddingValues, onLogout: () -> 
 }
 
 @Composable
-private fun PortraitPinContent(state: PinState, onLogoutButtonClicked: () -> Unit) {
+private fun PortraitLoanContent(state: LoanState, onLogoutButtonClicked: () -> Unit) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        // Logout
         TextButton(
             onClick = onLogoutButtonClicked,
             modifier = Modifier
@@ -211,37 +207,14 @@ private fun PortraitPinContent(state: PinState, onLogoutButtonClicked: () -> Uni
         ) {
             Text(stringResource(R.string.pin_logout))
         }
-        Spacer(Modifier.height(12.dp))
-        UserText(state.userNumber)
-        Spacer(Modifier.weight(1f))
-        BoxWithConstraints(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .fillMaxWidth(0.75f)
-                .wrapContentHeight()
-                .aspectRatio(1f)
-        ) {
-            CountDownIndicator(progress = state.progress, stroke = 12.dp)
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.fillMaxSize(0.8f)
-            ) {
-                Crossfade(state.timeText) { state ->
-                    AutoSizeText(state ?: "", style = MaterialTheme.typography.headlineMedium)
-                }
-                Spacer(modifier = Modifier.weight(1f))
-                PinText(state.pin, state.nextPin)
-                Spacer(modifier = Modifier.weight(1f))
 
-            }
-        }
         Spacer(Modifier.weight(1f))
         Spacer(Modifier.height(24.dp))
     }
 }
 
 @Composable
-private fun LandscapePinContent(state: PinState, onLogoutButtonClicked: () -> Unit) {
+private fun LandscapeLoanContent(state: LoanState, onLogoutButtonClicked: () -> Unit) {
     Box(modifier = Modifier.fillMaxSize()) {
 
         // Logout button
@@ -254,47 +227,7 @@ private fun LandscapePinContent(state: PinState, onLogoutButtonClicked: () -> Un
             Text(stringResource(R.string.pin_logout))
         }
 
-        Row(modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.Center) {
-            Spacer(Modifier.weight(0.25f / 4f))
-            Box(
-                modifier = Modifier
-                    .weight(0.25f)
-                    .padding(top = 48.dp)
-            ) {
-                UserText(state.userNumber, modifier = Modifier.align(Alignment.TopEnd))
-            }
 
-            Spacer(Modifier.weight(0.25f / 4f))
-            Box(
-                modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .weight(0.25f)
-                    .fillMaxHeight(0.8f)
-                    .aspectRatio(1f, true)
-            ) {
-                CountDownIndicator(
-                    progress = state.progress,
-                    stroke = 12.dp,
-                    modifier = Modifier.align(Alignment.Center)
-                )
-                AnimatedCounter(
-                    count = state.timeText.orEmpty(),
-                    style = MaterialTheme.typography.headlineMedium,
-                )
-            }
-            Spacer(Modifier.weight(0.25f / 4f))
-            Box(
-                modifier = Modifier
-                    .weight(0.25f)
-                    .padding(top = 48.dp)
-            ) {
-                PinText(
-                    state.pin, state.nextPin,
-                    modifier = Modifier.align(Alignment.TopStart)
-                )
-            }
-            Spacer(Modifier.weight(0.25f / 4f))
-        }
     }
 }
 
@@ -309,67 +242,5 @@ private fun UserText(userNumber: String?, modifier: Modifier = Modifier) {
             text = userNumber ?: "",
             style = MaterialTheme.typography.displayLarge.copy(fontSize = 48.sp)
         )
-    }
-}
-
-@Composable
-private fun PinText(pin: String?, nextPin: String?, modifier: Modifier = Modifier) {
-    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(stringResource(R.string.pin_label_pin), style = MaterialTheme.typography.titleMedium)
-        AnimatedCounter(
-            count = pin.orEmpty(),
-            style = MaterialTheme.typography.displayLarge.copy(fontSize = 48.sp),
-        )
-        Row(Modifier.offset((-6).dp)) {
-            Icon(
-                imageVector = Icons.Rounded.Undo,
-                contentDescription = "Next",
-                Modifier
-                    .alpha(0.5f)
-                    .offset(y = 2.dp)
-                    .rotate(225f)
-            )
-            Spacer(modifier = Modifier.width(2.dp))
-            AnimatedCounter(
-                count = nextPin.orEmpty(),
-                style = MaterialTheme.typography.headlineMedium,
-                modifier = Modifier.alpha(0.5f)
-            )
-        }
-    }
-}
-
-
-@Composable
-fun AnimatedCounter(
-    count: String,
-    modifier: Modifier = Modifier,
-    style: TextStyle = MaterialTheme.typography.bodyMedium
-) {
-    var oldCount by remember { mutableStateOf(count) }
-    SideEffect {
-        oldCount = count
-    }
-    Row(modifier = modifier) {
-        for (i in count.indices) {
-            val oldChar = oldCount.getOrNull(i)
-            val newChar = count[i]
-            val char = if (oldChar == newChar) {
-                oldCount[i]
-            } else {
-                count[i]
-            }
-            AnimatedContent(
-                targetState = char,
-                transitionSpec = { slideInVertically { it } togetherWith slideOutVertically { -it } },
-                label = "counter"
-            ) { c ->
-                Text(
-                    text = c.toString(),
-                    style = style,
-                    softWrap = false
-                )
-            }
-        }
     }
 }

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -42,6 +43,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -266,7 +268,10 @@ private fun PortraitLoanContent(
             label = { Text(stringResource(R.string.loans_qr_code_text_input)) },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = 16.dp),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Text
+            )
         )
 
         Button(
@@ -369,7 +374,10 @@ private fun LandscapeLoanContent(
                     inputText.value = filteredText
                 },
                 label = { Text(stringResource(R.string.loans_qr_code_text_input)) },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Text
+                )
             )
 
             // Unlock Button

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanScreen.kt
@@ -1,9 +1,12 @@
 package com.tcn.bicicas.ui.loan
 
+import android.content.Intent
 import com.tcn.bicicas.ui.components.login.LoginDialog
 import com.tcn.bicicas.ui.pin.PinState
 
 import android.content.res.Configuration
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
@@ -24,6 +27,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Undo
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -43,6 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -50,6 +55,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.tcn.bicicas.R
 import com.tcn.bicicas.ui.components.ScrollableAlertDialog
+import io.github.g00fy2.quickie.QRResult
+import io.github.g00fy2.quickie.ScanCustomCode
+import io.github.g00fy2.quickie.ScanQRCode
+import io.github.g00fy2.quickie.config.BarcodeFormat
+import io.github.g00fy2.quickie.config.ScannerConfig
 import org.koin.androidx.compose.getViewModel
 
 @Composable
@@ -198,6 +208,7 @@ private fun PortraitLoanContent(state: LoanState, onLogoutButtonClicked: () -> U
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+
         // Logout
         TextButton(
             onClick = onLogoutButtonClicked,
@@ -206,6 +217,40 @@ private fun PortraitLoanContent(state: LoanState, onLogoutButtonClicked: () -> U
                 .padding(vertical = 12.dp, horizontal = 4.dp)
         ) {
             Text(stringResource(R.string.pin_logout))
+        }
+        val ctx = LocalContext.current
+        val scanQrCodeLauncher = rememberLauncherForActivityResult(ScanCustomCode()) { result ->
+            val text = when (result) {
+                is QRResult.QRSuccess -> {
+                    result.content.rawValue
+                    // decoding with default UTF-8 charset when rawValue is null will not result in meaningful output, demo purpose
+                        ?: result.content.rawBytes?.let { String(it) }.orEmpty()
+                }
+                QRResult.QRUserCanceled -> "User canceled"
+                QRResult.QRMissingPermission -> "Missing permission"
+                is QRResult.QRError -> "${result.exception.javaClass.simpleName}: ${result.exception.localizedMessage}"
+            }
+            // handle QRResult
+            Toast.makeText(ctx, text, Toast.LENGTH_LONG).show()
+        }
+
+        Button(
+            onClick = {
+                scanQrCodeLauncher.launch( ScannerConfig.build {
+                    setBarcodeFormats(listOf(BarcodeFormat.FORMAT_QR_CODE)) // set interested barcode formats
+                    setOverlayStringRes(R.string.app_name) // string resource used for the scanner overlay
+                    //setOverlayDrawableRes(R.drawable.ic_scan_barcode) // drawable resource used for the scanner overlay
+                    setHapticSuccessFeedback(false) // enable (default) or disable haptic feedback when a barcode was detected
+                    setShowTorchToggle(true) // show or hide (default) torch/flashlight toggle button
+                    setShowCloseButton(true) // show or hide (default) close button
+                    setHorizontalFrameRatio(1f) // set the horizontal overlay ratio (default is 1 / square frame)
+                    setUseFrontCamera(false) // use the front camera
+                    setKeepScreenOn(true) // keep the device's screen turned on
+                })
+            },
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(text = "Escanear código QR")
         }
 
         Spacer(Modifier.weight(1f))

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanViewModel.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanViewModel.kt
@@ -1,0 +1,84 @@
+package com.tcn.bicicas.ui.loan
+
+
+import android.util.Log
+import androidx.core.content.ContentProviderCompat.requireContext
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.tcn.bicicas.data.model.HttpError
+import com.tcn.bicicas.data.model.NetworkError
+import com.tcn.bicicas.data.repository.LoanRepository
+import com.tcn.bicicas.ui.components.login.LoginError
+import com.tcn.bicicas.ui.components.qrscanner.QrCodeScanner
+import com.tcn.bicicas.ui.tickerFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class LoanViewModel(
+    private val loanRepository: LoanRepository,
+) : ViewModel() {
+
+    private val _loanState = MutableStateFlow(LoanState())
+    val loanState: StateFlow<LoanState> = _loanState.asStateFlow()
+
+    init {
+
+        // Update auth state
+        loanRepository.authenticatedState.onEach { loggedIn ->
+            _loanState.update { state -> state.copy(loggedIn = loggedIn) }
+        }.launchIn(viewModelScope)
+
+    }
+
+    fun login(username: String, password: String) {
+        _loanState.update { it.copy(loading = true, loginError = null) }
+        viewModelScope.launch {
+            loanRepository.authenticate(username, password)
+                .onSuccess { twoFactorAuth ->
+                    _loanState.update { state ->
+                        state.copy(
+                            loggedIn = true,
+                            loading = false,
+                        )
+                    }
+                }.onFailure { error ->
+                    val loginError = when (error) {
+                        is HttpError -> LoginError.WrongUserPass
+                        is NetworkError -> LoginError.Network
+                        else -> LoginError.Unknown
+                    }
+                    _loanState.update { state ->
+                        state.copy(loginError = loginError, loading = false)
+                    }
+                }
+        }
+    }
+
+    fun logout() {
+        loanRepository.logout()
+    }
+
+    fun listenToQrScanner(scanner: QrCodeScanner) {
+        viewModelScope.launch {
+            scanner.qrCodeFlow.collect { qrCode ->
+                handleQrCode(qrCode)
+            }
+        }
+    }
+
+    private fun handleQrCode(qrCode: String) {
+        // Your business logic here
+        Log.i("vik0t0r",qrCode)
+    }
+
+
+}

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanViewModel.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanViewModel.kt
@@ -13,6 +13,8 @@ import com.tcn.bicicas.data.repository.LoanRepository
 import com.tcn.bicicas.ui.components.login.LoginError
 import com.tcn.bicicas.ui.tickerFlow
 import io.github.g00fy2.quickie.QRResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanViewModel.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanViewModel.kt
@@ -2,14 +2,17 @@ package com.tcn.bicicas.ui.loan
 
 
 import android.util.Log
+import android.widget.Toast
 import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tcn.bicicas.data.model.HttpError
+import com.tcn.bicicas.data.model.Loan
 import com.tcn.bicicas.data.model.NetworkError
 import com.tcn.bicicas.data.repository.LoanRepository
 import com.tcn.bicicas.ui.components.login.LoginError
 import com.tcn.bicicas.ui.tickerFlow
+import io.github.g00fy2.quickie.QRResult
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,6 +24,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 
 class LoanViewModel(
     private val loanRepository: LoanRepository,
@@ -66,12 +70,49 @@ class LoanViewModel(
         loanRepository.logout()
     }
 
+    fun loanBike(bikeCode: String) {
+        _loanState.update { it.copy(loanLoading = true, loanError = null) }
 
+        viewModelScope.launch {
+            loanRepository.loanBike(bikeCode).onSuccess {
+                _loanState.update { state ->
+                    state.copy(
+                        loanSuccess = true,
+                        loanLoading = false
+                    )
+                }
+            }.onFailure { error ->
+                val loanError = when (error) {
+                    is HttpError -> {
+                        if (error.code == 403){
+                            logout()
+                            LoanState.LoanError.Unauthenticated
+                        } else {
+                            val errorStr = error.errorMessage?.let { JSONObject(it).getString("errors") }
+                            if (errorStr == "EXCEPTION_QR_NOT_EXIST"){
+                                LoanState.LoanError.NoQRCode
+                            } else if (errorStr == "EXCEPTION_BICYCLE_NOT_EXIST"){
+                                LoanState.LoanError.NoBicycle
+                            } else {
+                                LoanState.LoanError.Unknown
+                            }
+                        }
+                    }
+                    is NetworkError -> LoanState.LoanError.Network
+                    else -> LoanState.LoanError.Unknown
+                }
 
-    private fun handleQrCode(qrCode: String) {
-        // Your business logic here
-        Log.i("vik0t0r",qrCode)
+                _loanState.update { state ->
+                    state.copy(loanError = loanError, loanLoading = false)
+                }
+            }
+        }
     }
+
+    fun onLoanMsgShown() {
+        _loanState.update { it.copy(loanSuccess = false, loanError = null) }
+    }
+
 
 
 }

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanViewModel.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/loan/LoanViewModel.kt
@@ -9,7 +9,6 @@ import com.tcn.bicicas.data.model.HttpError
 import com.tcn.bicicas.data.model.NetworkError
 import com.tcn.bicicas.data.repository.LoanRepository
 import com.tcn.bicicas.ui.components.login.LoginError
-import com.tcn.bicicas.ui.components.qrscanner.QrCodeScanner
 import com.tcn.bicicas.ui.tickerFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -67,13 +66,7 @@ class LoanViewModel(
         loanRepository.logout()
     }
 
-    fun listenToQrScanner(scanner: QrCodeScanner) {
-        viewModelScope.launch {
-            scanner.qrCodeFlow.collect { qrCode ->
-                handleQrCode(qrCode)
-            }
-        }
-    }
+
 
     private fun handleQrCode(qrCode: String) {
         // Your business logic here

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/main/MainScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CameraEnhance
 import androidx.compose.material.icons.rounded.List
 import androidx.compose.material.icons.rounded.Map
 import androidx.compose.material.icons.rounded.Pin
@@ -38,6 +39,7 @@ import androidx.navigation.compose.rememberNavController
 import com.tcn.bicicas.R
 import com.tcn.bicicas.data.model.Settings
 import com.tcn.bicicas.data.model.Station
+import com.tcn.bicicas.ui.loan.LoanScreen
 import com.tcn.bicicas.ui.pin.PinScreen
 import com.tcn.bicicas.ui.settings.SettingsScreen
 import com.tcn.bicicas.ui.settings.SettingsViewModel
@@ -119,6 +121,7 @@ fun MainScreen(
 private val iconForScreen = { screen: Screen ->
     when (screen) {
         Screen.Pin -> Icons.Rounded.Pin
+        Screen.Loan -> Icons.Rounded.CameraEnhance
         Screen.List -> Icons.Rounded.List
         Screen.Map -> Icons.Rounded.Map
     }
@@ -152,13 +155,14 @@ private fun MainContent(
     val contentForScreen = @Composable { screen: Screen, padding: PaddingValues ->
         when (screen) {
             Screen.Pin -> PinScreen(padding)
+            Screen.Loan -> LoanScreen(padding)
             Screen.List -> StationScreen(padding, stationsViewModel)
             Screen.Map -> MapScreen(padding, stationsViewModel, mapState)
         }
     }
 
     val scrollBehavior = when (navigationState.screen) {
-        Screen.Pin, Screen.Map -> TopAppBarDefaults.pinnedScrollBehavior()
+        Screen.Pin, Screen.Map, Screen.Loan -> TopAppBarDefaults.pinnedScrollBehavior()
         Screen.List -> TopAppBarDefaults.enterAlwaysScrollBehavior()
     }
 

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/main/Screen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/main/Screen.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 
-enum class Screen { Pin, List, Map }
+enum class Screen { Pin, Loan, List, Map }
 
 data class NavigationState(
     val initialScreen: Screen,

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/pin/PinScreen.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/pin/PinScreen.kt
@@ -182,7 +182,7 @@ private fun PinContent(state: PinState, padding: PaddingValues, onLogout: () -> 
     if (displayLogoutDialog) {
         AlertDialog(
             onDismissRequest = { displayLogoutDialog = false },
-            title = { Text(stringResource(R.string.pin_logout)) },
+            title = { Text(stringResource(R.string.logout)) },
             text = { Text(stringResource(R.string.pin_logout_popup_text)) },
             confirmButton = { TextButton(onClick = onLogout) { Text(stringResource(R.string.popup_accept)) } },
             dismissButton = {
@@ -209,7 +209,7 @@ private fun PortraitPinContent(state: PinState, onLogoutButtonClicked: () -> Uni
                 .align(Alignment.End)
                 .padding(vertical = 12.dp, horizontal = 4.dp)
         ) {
-            Text(stringResource(R.string.pin_logout))
+            Text(stringResource(R.string.logout))
         }
         Spacer(Modifier.height(12.dp))
         UserText(state.userNumber)
@@ -251,7 +251,7 @@ private fun LandscapePinContent(state: PinState, onLogoutButtonClicked: () -> Un
                 .align(Alignment.TopEnd)
                 .padding(vertical = 4.dp, horizontal = 12.dp)
         ) {
-            Text(stringResource(R.string.pin_logout))
+            Text(stringResource(R.string.logout))
         }
 
         Row(modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.Center) {

--- a/app/src/main/kotlin/com/tcn/bicicas/ui/pin/PinViewModel.kt
+++ b/app/src/main/kotlin/com/tcn/bicicas/ui/pin/PinViewModel.kt
@@ -3,9 +3,12 @@ package com.tcn.bicicas.ui.pin
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tcn.bicicas.data.Clock
+import com.tcn.bicicas.data.andThen
 import com.tcn.bicicas.data.model.HttpError
 import com.tcn.bicicas.data.model.NetworkError
+import com.tcn.bicicas.data.repository.LoanRepository
 import com.tcn.bicicas.data.repository.PinRepository
+import com.tcn.bicicas.ui.components.login.LoginError
 import com.tcn.bicicas.ui.tickerFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,6 +25,7 @@ import kotlin.math.roundToInt
 
 class PinViewModel(
     private val pinRepository: PinRepository,
+    private val loanRepository: LoanRepository,
     private val clock: Clock,
 ) : ViewModel() {
 
@@ -30,10 +34,39 @@ class PinViewModel(
 
     init {
 
-        // Update auth state
-        pinRepository.authenticatedState.onEach { loggedIn ->
+        // this should authenticate pinRepository in case loanRepository gets authenticated
+        viewModelScope.launch {
+            combine(
+                loanRepository.authenticatedState,
+                pinRepository.authenticatedState
+            ) { loanAuthenticated, pinAuthenticated ->
+                loanAuthenticated to pinAuthenticated
+            }.collect { (loanAuthenticated, pinAuthenticated) ->
+                if (loanAuthenticated && !pinAuthenticated) {
+                    loanRepository.getToken()?.let {
+                        pinRepository.authenticateTwoFactor(it.value).onSuccess{ twoFactorAuth ->
+                            _pinState.update { state ->
+                                state.copy(
+                                    loggedIn = true,
+                                    loading = false,
+                                    userNumber = twoFactorAuth.user
+                                )
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+
+        // close pinRepository in case loanRepository is closed
+        loanRepository.authenticatedState.onEach { loggedIn ->
             _pinState.update { state -> state.copy(loggedIn = loggedIn) }
+            if (!loggedIn) {
+                pinRepository.logout()
+            }
         }.launchIn(viewModelScope)
+
 
         // Update progress every 500ms and pin on epoch changes (every 30s)
         tickerFlow(500)
@@ -73,29 +106,23 @@ class PinViewModel(
     fun login(username: String, password: String) {
         _pinState.update { it.copy(loading = true, loginError = null) }
         viewModelScope.launch {
-            pinRepository.authenticate(username, password)
-                .onSuccess { twoFactorAuth ->
-                    _pinState.update { state ->
-                        state.copy(
-                            loggedIn = true,
-                            loading = false,
-                            userNumber = twoFactorAuth.user
-                        )
-                    }
-                }.onFailure { error ->
+            loanRepository.authenticate(username, password)
+                .onFailure { error ->
                     val loginError = when (error) {
-                        is HttpError -> PinState.LoginError.WrongUserPass
-                        is NetworkError -> PinState.LoginError.Network
-                        else -> PinState.LoginError.Unknown
+                        is HttpError -> LoginError.WrongUserPass
+                        is NetworkError -> LoginError.Network
+                        else -> LoginError.Unknown
                     }
                     _pinState.update { state ->
                         state.copy(loginError = loginError, loading = false)
                     }
                 }
+
         }
     }
 
     fun logout() {
+        loanRepository.logout()
         pinRepository.logout()
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,4 +64,8 @@
     <string name="stations_list_status_updated_days_ago">Hace %1$d d</string>
     <string name="desbloqueo_mediante_codigo_qr">Desbloqueo mediante código QR</string>
 
+    <!-- Loans -->
+    <string name="qr_scan_string">Escanea el código QR</string>
+    <string name="escanear_c_digo_qr">Escanear código QR</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <!--Shared -->
     <string name="popup_accept">Aceptar</string>
     <string name="popup_cancel">Cancelar</string>
+    <string name="popup_success">Éxito</string>
+    <string name="popup_error_title">Error</string>
 
     <!--Settings-->
     <string name="settings_title_theme">Tema</string>
@@ -33,17 +35,19 @@
     <!--Pin-->
     <string name="pin_welcome_message">Para poder disfrutar de esta funcionalidad es necesario iniciar sesión con sus credenciales</string>
     <string name="pin_welcome_title_warning">Aviso</string>
-    <string name="pin_welcome_message_warning">Unnoficial Bicicas no es una aplicación oficial, las credenciales introducidas en esta aplicación se usan para poder acceder a los servidores oficiales de Bicicas directamente, sin intermediarios, mediante una conexión segura.
-        \n\nLas credenciales introducidas permanecen seguras, no son, en ningún caso, almacenadas en el dispositivo ni enviadas a servidores de terceros.
-        \n\nUnnoficial Bicicas no genera ningún tipo de ingreso, ni será nunca su intención, la única misión es ofrecer una alternativa moderna y fluida.
-    </string>
+    <string name="pin_welcome_message_warning">
+    Unofficial Bicicas no es una aplicación oficial. Las credenciales introducidas en esta aplicación se utilizan para acceder directamente a los servidores oficiales de Bicicas, sin intermediarios, mediante una conexión segura.
+    \n\nLas credenciales introducidas permanecen seguras y no se envían, bajo ningún concepto, a servidores de terceros.
+    \n\nSolo se puede mantener una sesión activa de Bicicas a la vez. Por lo tanto, si inicias sesión, se cerrará cualquier otra sesión que tengas abierta.
+    \n\nUnofficial Bicicas no genera ningún tipo de ingreso ni tiene la intención de hacerlo. Su única misión es ofrecer una alternativa moderna y fluida.
+</string>
     <string name="pin_welcome_button_continue">Continuar</string>
     <string name="pin_login_error_wrong_user_pass">Usuario o contaseña incorrectos</string>
     <string name="pin_login_error_network">Error de conectividad, compruebe la conexión o intentelo más tarde</string>
     <string name="pin_login_error_unknown">Error inesperado, intentelo más tarde</string>
     <string name="pin_welcome_title">Desbloqueo mediante código pin</string>
     <string name="pin_login">Iniciar sesión</string>
-    <string name="pin_logout">Cerrar sesión</string>
+    <string name="logout">Cerrar sesión</string>
     <string name="pin_field_username">Usuario</string>
     <string name="pin_field_password">Contraseña</string>
     <string name="pin_logout_popup_text">¿Desea cerrar sesión? Deberá volver a iniciar sesión para poder ver el pin.</string>
@@ -62,10 +66,16 @@
     <string name="stations_list_status_updated_minutes_ago">Hace %1$d m</string>
     <string name="stations_list_status_updated_hours_ago">Hace %1$d h</string>
     <string name="stations_list_status_updated_days_ago">Hace %1$d d</string>
-    <string name="desbloqueo_mediante_codigo_qr">Desbloqueo mediante código QR</string>
 
     <!-- Loans -->
-    <string name="qr_scan_string">Escanea el código QR</string>
-    <string name="escanear_c_digo_qr">Escanear código QR</string>
-
+    <string name="loans_qr_code_unlocking_msg">Desbloqueo mediante código QR</string>
+    <string name="loans_qr_scan_string">Escanea el código QR</string>
+    <string name="loans_success">Préstamo realizado correctamente</string>
+    <string name="loans_error_unauthenticated">Se ha cerrado la sesión</string>
+    <string name="loans_error_no_bicycle">No hay bicicleta en este anclaje</string>
+    <string name="loans_error_no_qr">El código QR no existe</string>
+    <string name="loans_error_network">Problema de red</string>
+    <string name="loans_error_unknown">Error desconocido</string>
+    <string name="loans_qr_code_text_input">Código QR</string>
+    <string name="loans_unlock_btn">Desbloquear</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <!--Pin-->
     <string name="pin_welcome_message">Para poder disfrutar de esta funcionalidad es necesario iniciar sesión con sus credenciales</string>
     <string name="pin_welcome_title_warning">Aviso</string>
-    <string name="pin_welcome_message_warning">Unnoficial Bicicas no es una aplicación oficial, las credenciales introducidas en esta aplicación se usan para poder acceder a los servidores oficiales de Bicicas directamente, sin intermediarios, mediante una conexión segura, para poder obtener la información necesaria para generar el código pin.
+    <string name="pin_welcome_message_warning">Unnoficial Bicicas no es una aplicación oficial, las credenciales introducidas en esta aplicación se usan para poder acceder a los servidores oficiales de Bicicas directamente, sin intermediarios, mediante una conexión segura.
         \n\nLas credenciales introducidas permanecen seguras, no son, en ningún caso, almacenadas en el dispositivo ni enviadas a servidores de terceros.
         \n\nUnnoficial Bicicas no genera ningún tipo de ingreso, ni será nunca su intención, la única misión es ofrecer una alternativa moderna y fluida.
     </string>
@@ -62,5 +62,6 @@
     <string name="stations_list_status_updated_minutes_ago">Hace %1$d m</string>
     <string name="stations_list_status_updated_hours_ago">Hace %1$d h</string>
     <string name="stations_list_status_updated_days_ago">Hace %1$d d</string>
+    <string name="desbloqueo_mediante_codigo_qr">Desbloqueo mediante código QR</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.application' version '8.1.3' apply false
-    id 'com.android.library' version '8.1.3' apply false
+    id 'com.android.application' version '8.8.0' apply false
+    id 'com.android.library' version '8.8.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.20' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
     id 'com.mikepenz.aboutlibraries.plugin' version '10.9.2' apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu May 25 16:06:36 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-rc-3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Esta PR implementa la funcionalidad solicitada en la issue #17. Dado que las nuevas estaciones de Bicicas requieren escanear un código QR en lugar de usar TOTP, se han realizado los siguientes cambios en la aplicación:

1. Se ha creado un nuevo LoanRepository, responsable de almacenar el token del usuario de forma persistente.

 2. Se ha desarrollado una nueva LoanScreen y su correspondiente LoanViewModel, que permiten desbloquear bicicletas introduciendo manualmente el código QR.

 3. Se ha integrado [esta librería](https://github.com/G00fY2/quickie) de escaneo de códigos QR para el desbloqueo.

## Problemas

Los servidores de Bicicas únicamente permiten tener una sesión activa por cuenta. Esto implica que si inicias sesión en esta aplicación, se cerrará la sesión en la app oficial, y viceversa. Es una limitación del sistema actual de autenticación de Bicicas y no de la implementación.

## Pruebas

He probado la funcionalidad con mi cuenta y todo parece funcionar correctamente. El flujo de autenticación, escaneo y desbloqueo funciona sin problemas, y la gestión del token se realiza correctamente.

## Prueba y validación

Si quieres probarlo, podemos quedar algún dia y vemos como va o te puedo prestar mi cuenta temporalmente para facilitar la validación.

**PD**: es la primera vez que utilizo este framework y este patrón de diseño, así que cualquier feedback es más que bienvenido 🙂.